### PR TITLE
Rename grid line scss variables to match CSS names

### DIFF
--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -1,2 +1,4 @@
-$base-line-height: 10.5pt;
-$grid-line-offset: 5.5pt;
+$grid-line-height: 10.5pt;
+// This is used to add an additional grid line between the baselines, that will be used when you set Grid alignment
+// ascender/top on components. This should normally match the x-height of fonts.
+$grid-top-line-offset: 5.5pt;

--- a/stylesheets/layout/_grid.scss
+++ b/stylesheets/layout/_grid.scss
@@ -6,8 +6,8 @@
 	right: 0;
 	padding: 0;
 
-	--alf-grid-line-height: #{$base-line-height};
-	--alf-grid-top-line-offset: #{$grid-line-offset};
+	--alf-grid-line-height: #{$grid-line-height};
+	--alf-grid-top-line-offset: #{$grid-top-line-offset};
 	--alf-grid-margin-inner: 17mm;
 	--alf-grid-margin-outer: 0;
 	--alf-grid-column-gap: 4mm;
@@ -16,7 +16,7 @@
 	[class*="alf-col-"] {
 		position: absolute;
 		margin-top: 0;
-		margin-bottom: $base-line-height;
+		margin-bottom: $grid-line-height;
 	}
 
 	.alf-col-top {

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -4,7 +4,7 @@
 	background: transparent;
 	box-sizing: border-box;
 	color: var(--color-black);
-	line-height: $base-line-height;
+	line-height: $grid-line-height;
 	text-rendering: geometricPrecision;
 	-ro-glyph-layout-mode: quality;
 	widows: 1;

--- a/stylesheets/utils/_dividers.scss
+++ b/stylesheets/utils/_dividers.scss
@@ -4,7 +4,7 @@
 	--divider-alignment: bottom;
 	--divider-color: var(--color-black);
 	--divider-thickness: var(--unit-thin);
-	height: $base-line-height;
+	height: $grid-line-height;
 	min-height: 0;
 	display: flex;
 	justify-content: center;

--- a/stylesheets/utils/_margin.scss
+++ b/stylesheets/utils/_margin.scss
@@ -10,10 +10,10 @@
 	$plural: if($i == 1, '', 's');
 
 	.u-margin-top--#{$i}-line#{$plural} {
-		margin-top: ($base-line-height * $i) !important;
+		margin-top: ($grid-line-height * $i) !important;
 	}
 
 	.u-margin-bottom--#{$i}-line#{$plural} {
-		margin-bottom: ($base-line-height * $i) !important;
+		margin-bottom: ($grid-line-height * $i) !important;
 	}
 }

--- a/templates/components/caption/caption.scss
+++ b/templates/components/caption/caption.scss
@@ -5,7 +5,7 @@
 		margin: 0;
 		font-family: Rubik-Regular;
 		font-size: 9pt;
-		line-height: $base-line-height;
+		line-height: $grid-line-height;
 	}
 
 	.headline {

--- a/templates/components/fact-box/fact-box.scss
+++ b/templates/components/fact-box/fact-box.scss
@@ -10,8 +10,8 @@
 		font-family: Rubik-SemiBold;
 		font-weight: normal;
 		font-size: 12pt;
-		line-height: $base-line-height;
-		padding-top: $base-line-height;
+		line-height: $grid-line-height;
+		padding-top: $grid-line-height;
 		margin-top: 6pt;
 		margin-bottom: 6pt;
 	}
@@ -19,11 +19,11 @@
 	.fact-box-body {
 		font-family: Rubik-Regular;
 		font-size: 9pt;
-		line-height: $base-line-height;
+		line-height: $grid-line-height;
 		transform: translateY(1.8pt);
 
 		p {
-			margin: 0 0 $base-line-height 0;
+			margin: 0 0 $grid-line-height 0;
 		}
 	}
 }

--- a/templates/components/intro/intro.scss
+++ b/templates/components/intro/intro.scss
@@ -5,7 +5,7 @@
 	line-height: 1.1em;
 	-ro-pdf-overprint: mode1;
 	-ro-pdf-overprint-content: mode1;
-	margin-bottom: $grid-line-offset;
+	margin-bottom: $grid-top-line-offset;
 	--alf-grid-align-top: top;
 	--alf-grid-align-bottom: baseline;
 	--alf-hyphens-after-first: 5;

--- a/templates/components/quote/quote.scss
+++ b/templates/components/quote/quote.scss
@@ -17,6 +17,6 @@
 
 	.quote-creator {
 		font-family: Rubik-LightItalic;
-		margin: $base-line-height 0 0 0;
+		margin: $grid-line-height 0 0 0;
 	}
 }

--- a/templates/components/text-column/text-column.scss
+++ b/templates/components/text-column/text-column.scss
@@ -17,7 +17,7 @@
 	.row {
 		display: block;
 		width: 100%;
-		height: $base-line-height;
+		height: $grid-line-height;
 	}
 
 	.alf-block {


### PR DESCRIPTION
Both me and Stewa have  assumed grid-line-offset should be the same as baseline offset in DrEdition. Rename to have same name as the CSS custom properties, and add a comment to explain what grid top line offset does.

